### PR TITLE
Expand test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ rvm:
   - 2.5.3
 env:
   global:
-    - BEAKER_PUPPET_COLLECTION=puppet6 PUPPET_GEM_VERSION="~> 6.0"
+    - PUPPET_GEM_VERSION="~> 6.0"
 matrix:
   fast_finish: true
   include:

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 #### Table of Contents
 
 1. [Description](#description)
-3. [Reference](#reference)
-4. [Limitations - OS compatibility, etc.](#limitations)
-5. [Development - Guide for contributing to the module](#development)
+2. [Reference](#reference)
+3. [Limitations - OS compatibility, etc.](#limitations)
+4. [Development - Guide for contributing to the module](#development)
 
 ## Description
 
@@ -14,7 +14,7 @@ Install and manage `cron` resources.
 
 ## Reference
 
-Please see `REFERENCE.md` for the reference documentation.
+Please see [`REFERENCE.md`](REFERENCE.md) for the reference documentation.
 
 This module is documented using Puppet Strings.
 

--- a/metadata.json
+++ b/metadata.json
@@ -5,6 +5,7 @@
   "summary": "Install and manage cron resources.",
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-cron_core",
+  "project_page": "https://github.com/puppetlabs/puppetlabs-cron_core",
   "issues_url": "https://tickets.puppetlabs.com/projects/MODULES",
   "dependencies": [
 

--- a/spec/lib/puppet_spec/compiler.rb
+++ b/spec/lib/puppet_spec/compiler.rb
@@ -29,12 +29,19 @@ module PuppetSpec::Compiler
   end
 
   def apply_compiled_manifest(manifest, prioritizer = Puppet::Graph::SequentialPrioritizer.new)
+    args = []
+    if Puppet.version.to_f < 5.0
+      args << 'apply'
+      # rubocop:disable RSpec/AnyInstance
+      Puppet::Transaction::Persistence.any_instance.stubs(:save)
+      # rubocop:enable RSpec/AnyInstance
+    end
     catalog = compile_to_ral(manifest)
     if block_given?
       catalog.resources.each { |res| yield res }
     end
     transaction = Puppet::Transaction.new(catalog,
-                                          Puppet::Transaction::Report.new,
+                                          Puppet::Transaction::Report.new(*args),
                                           prioritizer)
     transaction.evaluate
     transaction.report.finalize_report

--- a/spec/unit/provider/cron/parsed_spec.rb
+++ b/spec/unit/provider/cron/parsed_spec.rb
@@ -195,10 +195,14 @@ describe Puppet::Type.type(:cron).provider(:crontab) do
       end
 
       it 'contains no resources for a user who has no crontab, or for a user that is absent' do
-        Puppet::Util::Execution
-          .expects(:execute)
-          .with('crontab -u foobar -l', failonfail: true, combine: true)
-          .returns('')
+        if Puppet.version.to_f < 5.0
+          described_class.target_object('foobar').expects(:`).with('crontab -u foobar -l 2>/dev/null').returns ''
+        else
+          Puppet::Util::Execution
+            .expects(:execute)
+            .with('crontab -u foobar -l', failonfail: true, combine: true)
+            .returns('')
+        end
         expect(described_class.instances.select do |resource|
           resource.get('target') == 'foobar'
         end).to be_empty


### PR DESCRIPTION
Expand test coverage to include Puppet4 & Puppet6. Update README (see MODULES-8182) and project metadata.