### PR TITLE
(MODULES-8301) Update the unit tests with the crontab filetype fix

### DIFF
--- a/spec/unit/provider/cron/parsed_spec.rb
+++ b/spec/unit/provider/cron/parsed_spec.rb
@@ -195,12 +195,10 @@ describe Puppet::Type.type(:cron).provider(:crontab) do
       end
 
       it 'contains no resources for a user who has no crontab, or for a user that is absent' do
-        # `crontab...` does only capture stdout here. On vixie-cron-4.1
-        # STDERR shows "no crontab for foobar" but stderr is ignored as
-        # well as the exitcode.
-        # STDERR shows "crontab:  user `foobar' unknown" but stderr is
-        # ignored as well as the exitcode
-        described_class.target_object('foobar').expects(:`).with('crontab -u foobar -l 2>/dev/null').returns ''
+        Puppet::Util::Execution
+          .expects(:execute)
+          .with('crontab -u foobar -l', failonfail: true, combine: true)
+          .returns('')
         expect(described_class.instances.select do |resource|
           resource.get('target') == 'foobar'
         end).to be_empty


### PR DESCRIPTION
Commit 420049f2 in Puppet fixed the crontab filetype's #read method
to use Puppet::Util::Execution.execute instead of %x. This commit
updates the unit tests to account for this change.