### PR TITLE
Day ranges can only be numeric

### DIFF
--- a/lib/puppet/type/cron.rb
+++ b/lib/puppet/type/cron.rb
@@ -280,7 +280,9 @@ Puppet::Type.newtype(:cron) do
       must be either:
 
       -   A number between 0 and 7, inclusive, with 0 or 7 being Sunday
-      -   The name of the day, such as 'Tuesday'."
+      -   The name of the day, such as 'Tuesday'.
+
+      Day ranges can only be numeric; e.g. '1-5' for weekdays, but not 'Mon-Fri'."
   end
 
   newproperty(:month, parent: CronParam) do


### PR DESCRIPTION
The documentation is confusing on when day names are allowed. This should help clarify the confusion in the case of ranges.