### PR TITLE
(MODULES-7786) Allow leading zeroes for cron params

### DIFF
--- a/lib/puppet/type/cron.rb
+++ b/lib/puppet/type/cron.rb
@@ -73,9 +73,7 @@ Puppet::Type.newtype(:cron) do
     # in string form to actual integers, and returns the value if it's
     # an integer or false if it's just a normal string.
     def numfix(num)
-      if num =~ %r{^\d+$}
-        num.to_i
-      elsif num.is_a?(Integer)
+      if num =~ %r{^\d+$} || num.is_a?(Integer)
         num
       else
         false
@@ -85,7 +83,7 @@ Puppet::Type.newtype(:cron) do
     # Verify that a number is within the specified limits.  Return the
     # number if it is, or false if it is not.
     def limitcheck(num, lower, upper)
-      (num >= lower && num <= upper) && num
+      (num.to_i >= lower && num.to_i <= upper) && num
     end
 
     # Verify that a value falls within the specified array.  Does case

--- a/spec/acceptance/tests/resource/cron/should_write_leading_zeroes_spec.rb
+++ b/spec/acceptance/tests/resource/cron/should_write_leading_zeroes_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper_acceptance'
+
+RSpec.context 'when leading zeroes are present' do
+  before(:each) do
+    compatible_agents.each do |agent|
+      step 'ensure the user exists via puppet'
+      setup(agent)
+    end
+  end
+
+  after(:each) do
+    compatible_agents.each do |agent|
+      step 'Cron: cleanup'
+      clean(agent)
+    end
+  end
+
+  compatible_agents.each do |host|
+    it 'does not ignore leading zeroes' do
+      step 'apply the resource on the host' do
+        on(host, puppet_resource('cron', 'crontest', 'user=tstuser', 'command=/bin/true', 'ensure=present', "minute='05'", "hour='007'", "weekday='03'", "month='0011'", "monthday='07'"), acceptable_exit_codes: [0])
+      end
+
+      step 'Verify that crontab -l contains what you expected' do
+        run_cron_on(host, :list, 'tstuser') do
+          expect(stdout).to match(%r{05 007 07 0011 03 /bin/true})
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/type/cron_spec.rb
+++ b/spec/unit/type/cron_spec.rb
@@ -127,6 +127,15 @@ describe Puppet::Type.type(:cron), unless: Puppet.features.microsoft_windows? do
         # As it turns out cron does not complaining about steps that exceed the valid range
         # expect { described_class.new(:name => 'foo', :minute => '*/120' ) }.to raise_error(Puppet::Error, /is not a valid minute/)
       end
+
+      it 'supports values with leading zeros' do
+        expect { described_class.new(name: 'foo', minute: ['0', '0011', '044']) }.not_to raise_error
+        expect { described_class.new(name: 'foo', minute: '022') }.not_to raise_error
+      end
+
+      it 'does not remove leading zeroes' do
+        expect(described_class.new(name: 'foo', minute: '0045')[:minute]).to eq(['0045'])
+      end
     end
 
     describe 'hour' do
@@ -193,6 +202,15 @@ describe Puppet::Type.type(:cron), unless: Puppet.features.microsoft_windows? do
         expect { described_class.new(name: 'foo', hour: '*/2A') }.to raise_error(Puppet::Error, %r{\*/2A is not a valid hour})
         # As it turns out cron does not complaining about steps that exceed the valid range
         # expect { described_class.new(:name => 'foo', :hour => '*/26' ) }.to raise_error(Puppet::Error, /is not a valid hour/)
+      end
+
+      it 'supports values with leading zeros' do
+        expect { described_class.new(name: 'foo', hour: ['007', '1', '0023']) }.not_to raise_error
+        expect { described_class.new(name: 'foo', hour: '022') }.not_to raise_error
+      end
+
+      it 'does not remove leading zeroes' do
+        expect(described_class.new(name: 'foo', hour: '005')[:hour]).to eq(['005'])
       end
     end
 
@@ -276,6 +294,15 @@ describe Puppet::Type.type(:cron), unless: Puppet.features.microsoft_windows? do
         expect { described_class.new(name: 'foo', weekday: '*/2A') }.to raise_error(Puppet::Error, %r{\*/2A is not a valid weekday})
         # As it turns out cron does not complaining about steps that exceed the valid range
         # expect { described_class.new(:name => 'foo', :weekday => '*/9' ) }.to raise_error(Puppet::Error, /is not a valid weekday/)
+      end
+
+      it 'supports values with leading zeros' do
+        expect { described_class.new(name: 'foo', weekday: ['Mon', 'Wed', '05']) }.not_to raise_error
+        expect { described_class.new(name: 'foo', weekday: '007') }.not_to raise_error
+      end
+
+      it 'does not remove leading zeroes' do
+        expect(described_class.new(name: 'foo', weekday: '006')[:weekday]).to eq(['006'])
       end
     end
 
@@ -376,6 +403,15 @@ describe Puppet::Type.type(:cron), unless: Puppet.features.microsoft_windows? do
         # As it turns out cron does not complaining about steps that exceed the valid range
         # expect { described_class.new(:name => 'foo', :month => '*/13' ) }.to raise_error(Puppet::Error, /is not a valid month/)
       end
+
+      it 'supports values with leading zeros' do
+        expect { described_class.new(name: 'foo', month: ['007', '1', '0012']) }.not_to raise_error
+        expect { described_class.new(name: 'foo', month: ['Jan', '04', '0009']) }.not_to raise_error
+      end
+
+      it 'does not remove leading zeroes' do
+        expect(described_class.new(name: 'foo', month: '09')[:month]).to eq(['09'])
+      end
     end
 
     describe 'monthday' do
@@ -440,6 +476,15 @@ describe Puppet::Type.type(:cron), unless: Puppet.features.microsoft_windows? do
         expect { described_class.new(name: 'foo', monthday: '*/2A') }.to raise_error(Puppet::Error, %r{\*/2A is not a valid monthday})
         # As it turns out cron does not complaining about steps that exceed the valid range
         # expect { described_class.new(:name => 'foo', :monthday => '*/32' ) }.to raise_error(Puppet::Error, /is not a valid monthday/)
+      end
+
+      it 'supports values with leading zeros' do
+        expect { described_class.new(name: 'foo', monthday: ['007', '1', '0023']) }.not_to raise_error
+        expect { described_class.new(name: 'foo', monthday: '022') }.not_to raise_error
+      end
+
+      it 'does not remove leading zeroes' do
+        expect(described_class.new(name: 'foo', monthday: '01')[:monthday]).to eq(['01'])
       end
     end
 


### PR DESCRIPTION
When applying a cron manigest that contains leading zeroes in a periodic
attribute (hour, minute, month, monthday, weekday), puppet will strip
down the zeroes even if they are accepted by the system cron.

Now puppet will only convert to integer the periodic attributes when
validating them, but will not change the input from the manifest.