### PR TITLE
(MODULES-10852) Fix warnings introduced by Ruby 2.7

### DIFF
--- a/lib/puppet/type/cron.rb
+++ b/lib/puppet/type/cron.rb
@@ -73,7 +73,7 @@ Puppet::Type.newtype(:cron) do
     # in string form to actual integers, and returns the value if it's
     # an integer or false if it's just a normal string.
     def numfix(num)
-      if num =~ %r{^\d+$} || num.is_a?(Integer)
+      if num.is_a?(Integer) || num =~ %r{^\d+$}
         num
       else
         false
@@ -155,17 +155,17 @@ Puppet::Type.newtype(:cron) do
       end
 
       # Allow step syntax
-      if value =~ %r{^\*/[0-9]+$}
+      if value.to_s =~ %r{^\*/[0-9]+$}
         return value
       end
 
       # Allow ranges
-      if value =~ %r{^[0-9]+-[0-9]+$}
+      if value.to_s =~ %r{^[0-9]+-[0-9]+$}
         return value
       end
 
       # Allow ranges with step
-      if value =~ %r{^[0-9]+-[0-9]+/[0-9]+$}
+      if value.to_s =~ %r{^[0-9]+-[0-9]+/[0-9]+$}
         return value
       end
 


### PR DESCRIPTION
Ruby 2.7 introduced a warning for checking an Integer against a regular expression because this check always returns nil even though as a string it would respect the given regular expression. The functionality remained the same.

This commit makes sure that we first check if a value is an Integer before comparing it to a regular expression or transforms it into a String where the regular expression check is necessary.

Example of warnings seen while running `puppet agent -t` on a box with `puppetlabs-cron_core` module installed (with Puppet7 and ruby 2.7):
```
/opt/puppetlabs/puppet/vendor_modules/cron_core/lib/puppet/type/cron.rb:160: warning: deprecated Object#=~ is called on Integer; it always returns nil
/opt/puppetlabs/puppet/vendor_modules/cron_core/lib/puppet/type/cron.rb:165: warning: deprecated Object#=~ is called on Integer; it always returns nil
/opt/puppetlabs/puppet/vendor_modules/cron_core/lib/puppet/type/cron.rb:170: warning: deprecated Object#=~ is called on Integer; it always returns nil
/opt/puppetlabs/puppet/vendor_modules/cron_core/lib/puppet/type/cron.rb:76: warning: deprecated Object#=~ is called on Integer; it always returns nil
```