### PR TITLE
(MODULES-10953) Update metadata.json and pdk version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,6 +77,8 @@ Style/SymbolArray:
   EnforcedStyle: brackets
 RSpec/NamedSubject:
   Enabled: false
+RSpec/SubjectStub:
+  Enabled: false
 RSpec/MessageSpies:
   EnforcedStyle: receive
 Style/Documentation:

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ end
 
 group :release do
   gem "puppet-blacksmith", '~> 3.4',                                             require: false
-  gem "pdk",                                                                     platforms: [:ruby]
+  gem "pdk", '~> 2.0',                                                           platforms: [:ruby]
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/metadata.json
+++ b/metadata.json
@@ -12,70 +12,40 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystem": "CentOS"
     },
     {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystem": "OracleLinux"
     },
     {
-      "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystem": "RedHat"
     },
     {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystem": "Scientific"
     },
     {
-      "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "8"
-      ]
+      "operatingsystem": "Debian"
     },
     {
-      "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [
-        "16.04"
-      ]
+      "operatingsystem": "Ubuntu"
     },
     {
-      "operatingsystem": "Fedora",
-      "operatingsystemrelease": [
-        "25"
-      ]
+      "operatingsystem": "Fedora"
     },
     {
-      "operatingsystem": "Darwin",
-      "operatingsystemrelease": [
-        "16"
-      ]
+      "operatingsystem": "Darwin"
     },
     {
-      "operatingsystem": "SLES",
-      "operatingsystemrelease": [
-        "12"
-      ]
+      "operatingsystem": "SLES"
     },
     {
-      "operatingsystem": "Solaris",
-      "operatingsystemrelease": [
-        "11"
-      ]
+      "operatingsystem": "Solaris"
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "pdk-version": "1.14.0",

--- a/spec/integration/provider/cron/crontab_spec.rb
+++ b/spec/integration/provider/cron/crontab_spec.rb
@@ -7,17 +7,17 @@ describe Puppet::Type.type(:cron).provider(:crontab), unless: Puppet.features.mi
   include PuppetSpec::Compiler
 
   before :each do
-    Puppet::Type.type(:cron).stubs(:defaultprovider).returns described_class
-    described_class.stubs(:suitable?).returns true
-    Puppet::FileBucket::Dipper.any_instance.stubs(:backup) # rubocop:disable RSpec/AnyInstance
+    allow(Puppet::Type.type(:cron)).to receive(:defaultprovider).and_return described_class
+    allow(described_class).to receive(:suitable?).and_return true
+    allow_any_instance_of(Puppet::FileBucket::Dipper).to receive(:backup) # rubocop:disable RSpec/AnyInstance
 
     # I don't want to execute anything
-    described_class.stubs(:filetype).returns Puppet::Util::FileType::FileTypeFlat
-    described_class.stubs(:default_target).returns crontab_user1
+    allow(described_class).to receive(:filetype).and_return Puppet::Util::FileType::FileTypeFlat
+    allow(described_class).to receive(:default_target).and_return crontab_user1
 
     # I don't want to stub Time.now to get a static header because I don't know
     # where Time.now is used elsewhere, so just go with a very simple header
-    described_class.stubs(:header).returns "# HEADER: some simple\n# HEADER: header\n"
+    allow(described_class).to receive(:header).and_return "# HEADER: some simple\n# HEADER: header\n"
     FileUtils.cp(my_fixture('crontab_user1'), crontab_user1)
     FileUtils.cp(my_fixture('crontab_user2'), crontab_user2)
   end
@@ -113,9 +113,9 @@ describe Puppet::Type.type(:cron).provider(:crontab), unless: Puppet.features.mi
           MANIFEST
           apply_compiled_manifest(manifest) do |res|
             if res.ref == 'Cron[Entirely new resource]'
-              res.expects(:err).with(regexp_matches(%r{no command}))
+              expect(res).to receive(:err).with(%r{no command})
             else
-              res.expects(:err).never
+              expect(res).not_to receive(:err)
             end
           end
         end

--- a/spec/lib/puppet_spec/compiler.rb
+++ b/spec/lib/puppet_spec/compiler.rb
@@ -33,7 +33,7 @@ module PuppetSpec::Compiler
     if Puppet.version.to_f < 5.0
       args << 'apply'
       # rubocop:disable RSpec/AnyInstance
-      Puppet::Transaction::Persistence.any_instance.stubs(:save)
+      allow_any_instance_of(Puppet::Transaction::Persistence).to receive(:save)
       # rubocop:enable RSpec/AnyInstance
     end
     catalog = compile_to_ral(manifest)
@@ -51,7 +51,7 @@ module PuppetSpec::Compiler
 
   def apply_with_error_check(manifest)
     apply_compiled_manifest(manifest) do |res|
-      res.expects(:err).never
+      expect(res).not_to receive(:err)
     end
   end
 

--- a/spec/lib/puppet_spec/files.rb
+++ b/spec/lib/puppet_spec/files.rb
@@ -10,7 +10,7 @@ module PuppetSpec::Files
     $global_tempfiles ||= []
     $global_tempfiles.each do |path|
       begin
-        Dir.unstub(:entries)
+        allow(Dir).to receive(:entries).and_call_original
         FileUtils.rm_rf path, secure: true
       rescue Errno::ENOENT # rubocop:disable Lint/HandleExceptions
         # nothing to do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,7 @@ default_facts.each do |fact, value|
 end
 
 RSpec.configure do |c|
+  c.mock_with :rspec
   c.default_facts = default_facts
   c.before :each do
     # set to strictest setting for testing

--- a/spec/unit/type/cron_spec.rb
+++ b/spec/unit/type/cron_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe Puppet::Type.type(:cron), unless: Puppet.features.microsoft_windows? do
   let(:simple_provider) do
     provider_class = described_class.provide(:simple) { mk_resource_methods }
-    provider_class.stubs(:suitable?).returns true
+    allow(provider_class).to receive(:suitable?).and_return true
     provider_class
   end
 
   before :each do
-    described_class.stubs(:defaultprovider).returns simple_provider
+    allow(described_class).to receive(:defaultprovider).and_return simple_provider
   end
 
   after :each do
@@ -574,7 +574,7 @@ describe Puppet::Type.type(:cron), unless: Puppet.features.microsoft_windows? do
   end
 
   it 'defaults to user => root if Etc.getpwuid(Process.uid) returns nil (#12357)' do
-    Etc.expects(:getpwuid).returns(nil)
+    expect(Etc).to receive(:getpwuid).and_return(nil)
     entry = described_class.new(name: 'test_entry', ensure: :present)
     expect(entry.value(:user)).to eql 'root'
   end


### PR DESCRIPTION
To avoid having to update this everytime we release a new agent platform, it should be enough to specify the supported OS, without
specific versions. It is assumed that for each OS in metadata.json, the versions supported are the same as what the agent itself supports.