### PR TITLE
(maint) Pin the async gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,8 @@ group :development do
   gem "beaker-rspec"
   gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1.22')
   gem "github_changelog_generator",                                              require: false
+  # We can unpin async when we move to Ruby 3
+  gem 'async', '~> 1'
   gem "beaker-module_install_helper",                                            require: false
   gem "beaker-puppet_install_helper",                                            require: false
   gem "nokogiri",                                                                require: false


### PR DESCRIPTION
Async 2.0.0 requires Ruby 3, so we're pinning to 1.x.