### PR TITLE
(maint) Updates supported OS from Darwin to macOS

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,7 @@
       "operatingsystem": "Fedora"
     },
     {
-      "operatingsystem": "Darwin"
+      "operatingsystem": "macOS"
     },
     {
       "operatingsystem": "SLES"


### PR DESCRIPTION
`metadata.json` is primarily consumed by Puppet Forge, which
does not parse "Darwin" as a version of OS X / macOS when filtering
through operating systems.