### PR TITLE
(MODULES-11371) Updates legacy facts

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -51,7 +51,7 @@ end
 def setup(agent, o = {})
   o = { user: 'tstuser' }.merge(o)
   apply_manifest_on(agent, %(user { '%s': ensure => present, managehome => false }) % o[:user])
-  apply_manifest_on(agent, %(case $operatingsystem {
+  apply_manifest_on(agent, %(case $facts['os']['name'] {
                                 centos, redhat, fedora: {$cron = 'cronie'}
                                 solaris: { $cron = 'core-os' }
                                 default: {$cron ='cron'} }


### PR DESCRIPTION
Legacy facts are removed in Puppet 8. This commit updates a spec file from using legacy facts to using structured facts.