### PR TITLE
(PA-5954) Add Amazon linux to install the 'cronie' (instead of cron) module used in rpm based platforms

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -52,7 +52,7 @@ def setup(agent, o = {})
   o = { user: 'tstuser' }.merge(o)
   apply_manifest_on(agent, %(user { '%s': ensure => present, managehome => false }) % o[:user])
   apply_manifest_on(agent, %(case $facts['os']['name'] {
-                                centos, redhat, fedora: {$cron = 'cronie'}
+                                centos, redhat, fedora, amazon: {$cron = 'cronie'}
                                 solaris: { $cron = 'core-os' }
                                 default: {$cron ='cron'} }
                                 package {'cron': name=> $cron, ensure=>present, }))


### PR DESCRIPTION
Ran the experimental pipeline for
main: https://jenkins-platform.delivery.puppetlabs.net/view/__experimental%20automatic/job/experimental_auto_puppetlabs-cron_core_intn-sys_nightly-puppet_agent_main-module_adhoc/

7.x: https://jenkins-platform.delivery.puppetlabs.net/view/__experimental%20automatic/job/experimental_auto_puppetlabs-cron_core_intn-sys_nightly-puppet_agent_7.x-module_adhoc/