### PR TITLE
Update deprecated Beaker methods 

### DIFF
--- a/spec/acceptance/tests/resource/cron/should_create_cron_spec.rb
+++ b/spec/acceptance/tests/resource/cron/should_create_cron_spec.rb
@@ -18,13 +18,13 @@ RSpec.context 'when creating cron' do
   compatible_agents.each do |host|
     it 'creates a new cron job' do
       step 'apply the resource on the host using puppet resource'
-      on(host, puppet_resource('cron', 'crontest', 'user=tstuser', 'command=/bin/true', 'ensure=present')) do
-        expect(stdout).to match(%r{created})
+      on(host, puppet_resource('cron', 'crontest', 'user=tstuser', 'command=/bin/true', 'ensure=present')) do |result|
+        expect(result.stdout).to match(%r{created})
       end
 
       step 'verify that crontab -l contains what you expected'
-      run_cron_on(host, :list, 'tstuser') do
-        expect(stdout).to match(%r{\* \* \* \* \* /bin/true})
+      run_cron_on(host, :list, 'tstuser') do |result|
+        expect(result.stdout).to match(%r{\* \* \* \* \* /bin/true})
       end
     end
   end

--- a/spec/acceptance/tests/resource/cron/should_match_existing_spec.rb
+++ b/spec/acceptance/tests/resource/cron/should_match_existing_spec.rb
@@ -20,13 +20,13 @@ RSpec.context 'when matching cron' do
   compatible_agents.each do |host|
     it 'matches existing cron jobs' do
       step 'Apply the resource on the host using puppet resource'
-      on(host, puppet_resource('cron', 'crontest', 'user=tstuser', 'command=/bin/true', 'ensure=present')) do
-        expect(stdout).to match(%r{present})
+      on(host, puppet_resource('cron', 'crontest', 'user=tstuser', 'command=/bin/true', 'ensure=present')) do |result|
+        expect(result.stdout).to match(%r{present})
       end
 
       step 'Verify that crontab -l contains what you expected'
-      run_cron_on(host, :list, 'tstuser') do
-        expect(stdout).to match(%r{\* \* \* \* \* /bin/true})
+      run_cron_on(host, :list, 'tstuser') do |result|
+        expect(result.stdout).to match(%r{\* \* \* \* \* /bin/true})
       end
     end
   end

--- a/spec/acceptance/tests/resource/cron/should_not_overwrite_crontab_file_on_file_read_error_spec.rb
+++ b/spec/acceptance/tests/resource/cron/should_not_overwrite_crontab_file_on_file_read_error_spec.rb
@@ -1,26 +1,11 @@
 require 'spec_helper_acceptance'
 
 RSpec.context 'when Puppet cannot read a crontab file' do
-  # This test only makes sense for agents that shipped with PUP-9217's
-  # changes, so we do not want to run it on older agents.
-  def older_agent?(agent)
-    puppet_version = Gem::Version.new(on(agent, puppet('--version')).stdout.chomp)
-    minimum_puppet_version = if puppet_version < Gem::Version.new('6.0.0')
-                               Gem::Version.new('5.5.9')
-                             else
-                               Gem::Version.new('6.0.5')
-                             end
-
-    puppet_version < minimum_puppet_version
-  end
-
   let(:username) { "pl#{rand(999_999).to_i}" }
   let(:crontab_contents) { '6 6 6 6 6 /usr/bin/true' }
 
   before(:each) do
     compatible_agents.each do |agent|
-      next if older_agent?(agent)
-
       step "Create the user on #{agent}" do
         user_present(agent, username)
       end
@@ -34,8 +19,6 @@ RSpec.context 'when Puppet cannot read a crontab file' do
 
   after(:each) do
     compatible_agents.each do |agent|
-      next if older_agent?(agent)
-
       step "Teardown -- Erase the user on #{agent}" do
         run_cron_on(agent, :remove, username)
         user_absent(agent, username)
@@ -45,10 +28,6 @@ RSpec.context 'when Puppet cannot read a crontab file' do
 
   compatible_agents.each do |agent|
     it "does not overwrite it on #{agent}" do
-      if older_agent?(agent)
-        skip('Skipping this test since we are on an older agent that does not have the PUP-9217 changes')
-      end
-
       crontab_exe = nil
       step 'Find the crontab executable' do
         crontab_exe = on(agent, 'which crontab').stdout.chomp

--- a/spec/acceptance/tests/resource/cron/should_only_fail_associated_resources_on_file_read_error_spec.rb
+++ b/spec/acceptance/tests/resource/cron/should_only_fail_associated_resources_on_file_read_error_spec.rb
@@ -1,26 +1,11 @@
 require 'spec_helper_acceptance'
 
 RSpec.context 'when Puppet cannot read a crontab file' do
-  # This test only makes sense for agents that shipped with PUP-9217's
-  # changes, so we do not want to run it on older agents.
-  def older_agent?(agent)
-    puppet_version = Gem::Version.new(on(agent, puppet('--version')).stdout.chomp)
-    minimum_puppet_version = if puppet_version < Gem::Version.new('6.0.0')
-                               Gem::Version.new('5.5.9')
-                             else
-                               Gem::Version.new('6.0.5')
-                             end
-
-    puppet_version < minimum_puppet_version
-  end
-
   let(:username) { "pl#{rand(999_999).to_i}" }
   let(:failed_username) { "pl#{rand(999_999).to_i}" }
 
   before(:each) do
     compatible_agents.each do |agent|
-      next if older_agent?(agent)
-
       step "Create the users on #{agent}" do
         user_present(agent, username)
         user_present(agent, failed_username)
@@ -30,8 +15,6 @@ RSpec.context 'when Puppet cannot read a crontab file' do
 
   after(:each) do
     compatible_agents.each do |agent|
-      next if older_agent?(agent)
-
       step "Teardown -- Erase the users on #{agent}" do
         run_cron_on(agent, :remove, username)
         user_absent(agent, username)
@@ -43,10 +26,6 @@ RSpec.context 'when Puppet cannot read a crontab file' do
 
   compatible_agents.each do |agent|
     it "onlies fail the associated resources on #{agent}" do
-      if older_agent?(agent)
-        skip('Skipping this test since we are on an older agent that does not have the PUP-9217 changes')
-      end
-
       crontab_exe = nil
       step 'Find the crontab executable' do
         crontab_exe = on(agent, 'which crontab').stdout.chomp

--- a/spec/acceptance/tests/resource/cron/should_only_fail_associated_resources_on_file_read_error_spec.rb
+++ b/spec/acceptance/tests/resource/cron/should_only_fail_associated_resources_on_file_read_error_spec.rb
@@ -100,7 +100,7 @@ SCRIPT
       end
 
       step 'Verify that Puppet does not fail a Cron resource associated with a readable crontab file' do
-        assert_no_match(%r{Cron.*first_entry}, puppet_result.stderr, 'Puppet fails a Cron resource associated with a readable crontab file')
+        refute_match(%r{Cron.*first_entry}, puppet_result.stderr, 'Puppet fails a Cron resource associated with a readable crontab file')
       end
 
       step 'Verify that Puppet successfully evaluates a Cron resource associated with a readable crontab file' do

--- a/spec/acceptance/tests/resource/cron/should_remove_cron_spec.rb
+++ b/spec/acceptance/tests/resource/cron/should_remove_cron_spec.rb
@@ -22,13 +22,13 @@ RSpec.context 'when removing crontab' do
 
       step 'apply the resource on the host using puppet resource'
       on(host, puppet_resource('cron', 'crontest', 'user=tstuser',
-                               'command=/bin/true', 'ensure=absent')) do
-        expect(stdout).to match(%r{crontest\D+ensure:\s+removed})
+                               'command=/bin/true', 'ensure=absent')) do |result|
+        expect(result.stdout).to match(%r{crontest\D+ensure:\s+removed})
       end
 
       step ' contains what you expected'
-      run_cron_on(host, :list, 'tstuser') do
-        expect(stderr).not_to match(%r{/bin/true})
+      run_cron_on(host, :list, 'tstuser') do |result|
+        expect(result.stderr).not_to match(%r{/bin/true})
       end
     end
   end

--- a/spec/acceptance/tests/resource/cron/should_remove_leading_and_trailing_whitespace_spec.rb
+++ b/spec/acceptance/tests/resource/cron/should_remove_leading_and_trailing_whitespace_spec.rb
@@ -18,23 +18,23 @@ RSpec.context 'when stripping whitespace from cron jobs' do
   agents.each do |host|
     it 'removes leading and trailing whitespace from cron jobs' do
       step 'apply the resource on the host using puppet resource'
-      on(host, puppet_resource('cron', 'crontest', 'user=tstuser', "command='   date > /dev/null    '", 'ensure=present')) do
-        expect(stdout).to match(%r{created})
+      on(host, puppet_resource('cron', 'crontest', 'user=tstuser', "command='   date > /dev/null    '", 'ensure=present')) do |result|
+        expect(result.stdout).to match(%r{created})
       end
 
       step 'verify the added crontab entry has stripped whitespace'
-      run_cron_on(host, :list, 'tstuser') do
-        expect(stdout).to match(%r{\* \* \* \* \* date > .dev.null})
+      run_cron_on(host, :list, 'tstuser') do |result|
+        expect(result.stdout).to match(%r{\* \* \* \* \* date > .dev.null})
       end
 
       step 'apply the resource with trailing whitespace and check nothing happened'
-      on(host, puppet_resource('cron', 'crontest', 'user=tstuser', "command='date > /dev/null    '", 'ensure=present')) do
-        expect(stdout).not_to match(%r{ensure: created})
+      on(host, puppet_resource('cron', 'crontest', 'user=tstuser', "command='date > /dev/null    '", 'ensure=present')) do |result|
+        expect(result.stdout).not_to match(%r{ensure: created})
       end
 
       step 'apply the resource with leading whitespace and check nothing happened'
-      on(host, puppet_resource('cron', 'crontest', 'user=tstuser', "command='     date > /dev/null'", 'ensure=present')) do
-        expect(stdout).not_to match(%r{ensure: created})
+      on(host, puppet_resource('cron', 'crontest', 'user=tstuser', "command='     date > /dev/null'", 'ensure=present')) do |result|
+        expect(result.stdout).not_to match(%r{ensure: created})
       end
     end
   end

--- a/spec/acceptance/tests/resource/cron/should_remove_matching_spec.rb
+++ b/spec/acceptance/tests/resource/cron/should_remove_matching_spec.rb
@@ -21,13 +21,13 @@ RSpec.context 'when removing crontabs' do
   compatible_agents.each do |host|
     it 'removes crontabs based on matching' do
       step 'Remove cron resource'
-      on(host, puppet_resource('cron', 'bogus', 'user=tstuser', 'command=/bin/true', 'ensure=absent')) do
-        expect(stdout).to match(%r{bogus\D+ensure: removed})
+      on(host, puppet_resource('cron', 'bogus', 'user=tstuser', 'command=/bin/true', 'ensure=absent')) do |result|
+        expect(result.stdout).to match(%r{bogus\D+ensure: removed})
       end
 
       step 'verify that crontab -l contains what you expected'
-      run_cron_on(host, :list, 'tstuser') do
-        expect(stdout.scan('/bin/true').length).to eq(0)
+      run_cron_on(host, :list, 'tstuser') do |result|
+        expect(result.stdout.scan('/bin/true').length).to eq(0)
       end
     end
   end

--- a/spec/acceptance/tests/resource/cron/should_update_existing_spec.rb
+++ b/spec/acceptance/tests/resource/cron/should_update_existing_spec.rb
@@ -21,18 +21,18 @@ RSpec.context 'when updating cron jobs' do
   compatible_agents.each do |host|
     it 'updates existing cron entries' do
       step 'verify that crontab -l contains what you expected'
-      run_cron_on(host, :list, 'tstuser') do
-        expect(stdout).to match(%r{\* \* \* \* \* /bin/true})
+      run_cron_on(host, :list, 'tstuser') do |result|
+        expect(result.stdout).to match(%r{\* \* \* \* \* /bin/true})
       end
 
       step 'apply the resource change on the host'
-      on(host, puppet_resource('cron', 'crontest', 'user=tstuser', 'command=/bin/true', 'ensure=present', "hour='0-6'")) do
-        expect(stdout).to match(%r{hour\s+=>\s+\['0-6'\]})
+      on(host, puppet_resource('cron', 'crontest', 'user=tstuser', 'command=/bin/true', 'ensure=present', "hour='0-6'")) do |result|
+        expect(result.stdout).to match(%r{hour\s+=>\s+\['0-6'\]})
       end
 
       step 'verify that crontab -l contains what you expected'
-      run_cron_on(host, :list, 'tstuser') do
-        expect(stdout).to match(%r{\* 0-6 \* \* \* /bin/true})
+      run_cron_on(host, :list, 'tstuser') do |result|
+        expect(result.stdout).to match(%r{\* 0-6 \* \* \* /bin/true})
       end
     end
   end

--- a/spec/acceptance/tests/resource/cron/should_write_leading_zeroes_spec.rb
+++ b/spec/acceptance/tests/resource/cron/should_write_leading_zeroes_spec.rb
@@ -22,8 +22,8 @@ RSpec.context 'when leading zeroes are present' do
       end
 
       step 'Verify that crontab -l contains what you expected' do
-        run_cron_on(host, :list, 'tstuser') do
-          expect(stdout).to match(%r{05 007 07 0011 03 /bin/true})
+        run_cron_on(host, :list, 'tstuser') do |result|
+          expect(result.stdout).to match(%r{05 007 07 0011 03 /bin/true})
         end
       end
     end


### PR DESCRIPTION
This PR updates several deprecated Beaker methods that were removed entirely in Beaker 5. This is in preparation for moving to Beaker 5 for tests.