### PR TITLE
(PA-6139) Drop beaker-puppet_install_helper gem in cron-core module

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -28,7 +28,6 @@ Gemfile:
       - gem: async
         version: '~> 1'
       - gem: beaker-module_install_helper
-      - gem: beaker-puppet_install_helper
       - gem: nokogiri
     ":system_tests":
       - gem: voxpupuli-acceptance

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,6 @@ group :development do
   gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 4') if Gem::Requirement.create('< 3.2.0').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "async", '~> 1',                                                       require: false
   gem "beaker-module_install_helper",                                        require: false
-  gem "beaker-puppet_install_helper",                                        require: false
   gem "nokogiri",                                                            require: false
 end
 group :development, :release_prep do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,7 +1,6 @@
 require 'beaker-rspec'
 require 'beaker-puppet'
 require 'beaker/module_install_helper'
-require 'beaker/puppet_install_helper'
 require 'voxpupuli/acceptance/spec_helper_acceptance'
 
 $LOAD_PATH << File.join(__dir__, 'acceptance/lib')
@@ -99,6 +98,30 @@ end
 RSpec.configure do |c|
   c.before :suite do
     unless ENV['BEAKER_provision'] == 'no'
+      def run_puppet_install_helper
+        return unless ENV['PUPPET_INSTALL_TYPE'] == 'agent'
+        if ENV['BEAKER_PUPPET_COLLECTION'].match? %r{/-nightly$/}
+          # Workaround for RE-10734
+          options[:release_apt_repo_url] = 'http://nightlies.puppet.com/apt'
+          options[:win_download_url] = 'http://nightlies.puppet.com/downloads/windows'
+          options[:mac_download_url] = 'http://nightlies.puppet.com/downloads/mac'
+        end
+
+        agent_sha = ENV['BEAKER_PUPPET_AGENT_SHA'] || ENV['PUPPET_AGENT_SHA']
+        if agent_sha.nil? || agent_sha.empty?
+          install_puppet_agent_on(hosts, options.merge(version: version))
+        else
+          # If we have a development sha, assume we're testing internally
+          dev_builds_url = ENV['DEV_BUILDS_URL'] || 'http://builds.delivery.puppetlabs.net'
+          install_from_build_data_url('puppet-agent', "#{dev_builds_url}/puppet-agent/#{agent_sha}/artifacts/#{agent_sha}.yaml", hosts)
+        end
+
+        # XXX install_puppet_agent_on() will only add_aio_defaults_on when the
+        # nodeset type == 'aio', but we don't want to depend on that.
+        add_aio_defaults_on(hosts)
+        add_puppet_paths_on(hosts)
+      end
+
       hosts.each { |host| host[:type] = 'aio' }
       run_puppet_install_helper
       install_module_on(hosts_as('default'))


### PR DESCRIPTION
beaker-puppet_install_helper 0.9.8 cannot be used with beaker 5 hence removing the dependency.