### PR TITLE
fix idempotency for empty environment

### DIFF
--- a/lib/puppet/provider/cron/crontab.rb
+++ b/lib/puppet/provider/cron/crontab.rb
@@ -221,7 +221,7 @@ Puppet::Type.type(:cron).provide(:crontab, parent: Puppet::Provider::ParsedFile,
           record[:unmanaged] = true
         end
         if envs.nil? || envs.empty?
-          record[:environment] = :absent
+          record[:environment] = []
         else
           # Collect all of the environment lines, and mark the records to be skipped,
           # since their data is included in our crontab record.

--- a/spec/acceptance/tests/resource/cron/should_be_idempotent_spec.rb
+++ b/spec/acceptance/tests/resource/cron/should_be_idempotent_spec.rb
@@ -18,14 +18,14 @@ RSpec.context 'when checking idempotency' do
   compatible_agents.each do |agent|
     it "ensures idempotency on #{agent}" do
       step 'Cron: basic - verify that it can be created'
-      result = apply_manifest_on(agent, 'cron { "myjob": command => "/bin/true", user    => "tstuser", hour    => "*", minute  => [1], ensure  => present,}')
+      result = apply_manifest_on(agent, 'cron { "myjob": command => "/bin/true", user    => "tstuser", hour    => "*", minute  => [1], ensure  => present, environment => [],}')
       expect(result.stdout).to match(%r{ensure: created})
 
       result = run_cron_on(agent, :list, 'tstuser')
       expect(result.stdout).to match(%r{. . . . . .bin.true})
 
       step 'Cron: basic - should not create again'
-      result = apply_manifest_on(agent, 'cron { "myjob": command => "/bin/true", user    => "tstuser", hour    => "*", minute  => [1], ensure  => present,}')
+      result = apply_manifest_on(agent, 'cron { "myjob": command => "/bin/true", user    => "tstuser", hour    => "*", minute  => [1], ensure  => present, environment => [],}')
       expect(result.stdout).not_to match(%r{ensure: created})
     end
   end


### PR DESCRIPTION
An idempotent issue is present with `puppetlabs-cron_core` when `environment => []` .
We use this into puppet-letsencrypt :
https://github.com/voxpupuli/puppet-letsencrypt/issues/360
https://github.com/voxpupuli/puppet-letsencrypt/blob/master/manifests/renew.pp#L83

`environment => []`  is used at least in one exemple https://github.com/puppetlabs/puppetlabs-cron_core/blob/main/spec/integration/provider/cron/crontab_spec.rb#L202So it looks expected as a possible usage. I did not found a tests that check idempotency about this usage.

This PR intent a fix of this