### PR TITLE
Install released puppet and facter gems

### DIFF
--- a/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   daily_unit_tests_with_nightly_puppet_gem:
     uses: "puppetlabs/phoenix-github-actions/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml@main"
+    secrets: inherit
 
   notify-via-slack:
     name: Notify workflow conclusion via Slack

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -11,6 +11,8 @@ on:
 jobs:
   Nightly:
     uses: "puppetlabs/phoenix-github-actions/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml@main"
+    secrets: inherit
   
   Released:
     uses: "puppetlabs/phoenix-github-actions/.github/workflows/unit_tests_with_released_puppet_gem.yaml@main"
+    secrets: inherit

--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,14 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 def location_for(place_or_version, fake_version = nil)
   git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}
   file_url_regex = %r{\Afile:\/\/(?<path>.*)}
+  source_url_regex = %r{\Asource:(?<url>[^#]*)(#(?<version>.*))?}
 
   if place_or_version && (git_url = place_or_version.match(git_url_regex))
     [fake_version, { git: git_url[:url], branch: git_url[:branch], require: false }].compact
   elsif place_or_version && (file_url = place_or_version.match(file_url_regex))
     ['>= 0', { path: File.expand_path(file_url[:path]), require: false }]
+  elsif place_or_version && (source = place_or_version.match(source_url_regex))
+    [source[:version], { require: false, source: source[:url] }]
   else
     [place_or_version, { require: false }]
   end


### PR DESCRIPTION
This updates unit tests to run against released versions of puppetcore gems. This PR is blocked on https://github.com/puppetlabs/phoenix-github-actions/pull/26